### PR TITLE
Fix issue #38: Add support for spaces and commas within alt dict

### DIFF
--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/PluginParameter.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/PluginParameter.java
@@ -67,9 +67,16 @@ public abstract class PluginParameter {
     public static final String SONAR_SPELL_CHECK_ISSUE_DATA_PROPERTY_KEY = "spell-check-issue-key";
 
     /**
-     * Separator for store alternate dictionary
+     * Separator for read and split alternate dictionary.
+     * Whitespace in each word will be trimmed, during reading.
      */
     public static final String SEPARATOR_CHAR = ",";
+    
+    /**
+     * Separator for store alternate dictionary
+     */
+    public static final String EXTENDED_SEPARATOR = SEPARATOR_CHAR + " ";
+    
 
     /**
      * Parameters for set cost of spelling

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/issue/tracking/AddWordFromIssueFunction.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/issue/tracking/AddWordFromIssueFunction.java
@@ -1,7 +1,6 @@
 package com.epam.sonarqube.spellcheck.plugin.issue.tracking;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
@@ -53,7 +52,12 @@ public class AddWordFromIssueFunction implements Function, ServerExtension {
             propertiesDao.saveGlobalProperties(pluginProperties);
         } else {
             String dictionary = propertyDto.getValue();
-            ArrayList<String> wordList = new ArrayList<>(Arrays.asList(dictionary.split(PluginParameter.SEPARATOR_CHAR)));
+            String[] wordArr = dictionary.split(PluginParameter.SEPARATOR_CHAR);
+            ArrayList<String> wordList = new ArrayList<>(wordArr.length);
+            for(String word : wordArr) {
+                wordList.add(word.trim());
+            }
+            
             writeSortedIfUnique(misspelledWord, dictionary, wordList);
         }
     }
@@ -64,7 +68,7 @@ public class AddWordFromIssueFunction implements Function, ServerExtension {
         } else {
             wordList.add(misspelledWord);
             Collections.sort(wordList);
-            String sortedDictionary = StringUtils.join(wordList, PluginParameter.SEPARATOR_CHAR);
+            String sortedDictionary = StringUtils.join(wordList, PluginParameter.EXTENDED_SEPARATOR);
             propertiesDao.updateProperties(PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY, dictionary, sortedDictionary);
             LOGGER.info("Added misspelledWord '{}' to dictionary.", misspelledWord);
         }

--- a/src/test/java/com/epam/sonarqube/spellcheck/plugin/issue/tracking/AddWordFromIssueFunctionTest.java
+++ b/src/test/java/com/epam/sonarqube/spellcheck/plugin/issue/tracking/AddWordFromIssueFunctionTest.java
@@ -3,6 +3,7 @@ package com.epam.sonarqube.spellcheck.plugin.issue.tracking;
 import static com.epam.sonarqube.spellcheck.plugin.PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY;
 import static com.epam.sonarqube.spellcheck.plugin.PluginParameter.ERROR_DESCRIPTION;
 import static com.epam.sonarqube.spellcheck.plugin.PluginParameter.SEPARATOR_CHAR;
+import static com.epam.sonarqube.spellcheck.plugin.PluginParameter.EXTENDED_SEPARATOR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
@@ -44,6 +45,7 @@ public class AddWordFromIssueFunctionTest {
 
     private static final String FIRST_WORD = "existWord";
     private static final String UNSORTED_WORD = "zoo";
+    private static final String UNSORTED_WORD2 = "zebra";
     private static final String NEW_WORD = "newWord";
     @Mock
     private IssueUpdater issueUpdater;
@@ -68,7 +70,7 @@ public class AddWordFromIssueFunctionTest {
         propertyDto.setValue(FIRST_WORD);
         when(propertiesDao.selectGlobalProperty(ALTERNATIVE_DICTIONARY_PROPERTY_KEY)).thenReturn(propertyDto);
         addWordFromIssueFunction.execute(context);
-        verify(propertiesDao).updateProperties(ALTERNATIVE_DICTIONARY_PROPERTY_KEY, FIRST_WORD, FIRST_WORD + SEPARATOR_CHAR + NEW_WORD);
+        verify(propertiesDao).updateProperties(ALTERNATIVE_DICTIONARY_PROPERTY_KEY, FIRST_WORD, FIRST_WORD + EXTENDED_SEPARATOR + NEW_WORD);
     }
 
     @Test
@@ -76,7 +78,27 @@ public class AddWordFromIssueFunctionTest {
         propertyDto.setValue(UNSORTED_WORD);
         when(propertiesDao.selectGlobalProperty(ALTERNATIVE_DICTIONARY_PROPERTY_KEY)).thenReturn(propertyDto);
         addWordFromIssueFunction.execute(context);
-        verify(propertiesDao).updateProperties(ALTERNATIVE_DICTIONARY_PROPERTY_KEY, UNSORTED_WORD, NEW_WORD + SEPARATOR_CHAR + UNSORTED_WORD);
+        verify(propertiesDao).updateProperties(ALTERNATIVE_DICTIONARY_PROPERTY_KEY, UNSORTED_WORD, NEW_WORD + EXTENDED_SEPARATOR + UNSORTED_WORD);
+    }
+    
+    @Test
+    public void shouldSortPropertyWithWhitespaceWhenUpdateIt() {
+        final String dictionary = UNSORTED_WORD2 + EXTENDED_SEPARATOR + UNSORTED_WORD; 
+        propertyDto.setValue(dictionary);
+        when(propertiesDao.selectGlobalProperty(ALTERNATIVE_DICTIONARY_PROPERTY_KEY)).thenReturn(propertyDto);
+        addWordFromIssueFunction.execute(context);
+        final String sortedDictionary = NEW_WORD + EXTENDED_SEPARATOR + dictionary; 
+        verify(propertiesDao).updateProperties(ALTERNATIVE_DICTIONARY_PROPERTY_KEY, dictionary, sortedDictionary);
+    }
+    
+    @Test
+    public void shouldSortPropertyWithoutWhitespaceWhenUpdateIt() {
+        final String dictionary = UNSORTED_WORD2 + SEPARATOR_CHAR + UNSORTED_WORD; 
+        propertyDto.setValue(dictionary);
+        when(propertiesDao.selectGlobalProperty(ALTERNATIVE_DICTIONARY_PROPERTY_KEY)).thenReturn(propertyDto);
+        addWordFromIssueFunction.execute(context);
+        final String sortedDictionary = NEW_WORD + EXTENDED_SEPARATOR + UNSORTED_WORD2 + EXTENDED_SEPARATOR + UNSORTED_WORD; 
+        verify(propertiesDao).updateProperties(ALTERNATIVE_DICTIONARY_PROPERTY_KEY, dictionary, sortedDictionary);
     }
 
     @Test


### PR DESCRIPTION
Add support for spaces and commas within alternative dictionary to improve readability.

Commas are used as separator. Spaces are used for better readability.
During analysis redundant spaces are trimmed from words in alternative dictionary.