### PR TITLE
Fix issue #40: setting sonarqube-spellcheck.spell.ignore.mixed.case =…

### DIFF
--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/SpellCheckPlugin.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/SpellCheckPlugin.java
@@ -46,25 +46,13 @@ public class SpellCheckPlugin extends SonarPlugin {
                                 .type(PropertyType.INTEGER).description("Defines minimum word length to analyse")
                                 .defaultValue("3").subCategory(SPELL_CHECKER_CATEGORY).build(),
 
-                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREMIXEDCASE).name("Ignore mixed case")
-                                .type(PropertyType.BOOLEAN).description("Words that have mixed case are not spell checked, example: 'SpellChecker'").defaultValue("false").subCategory(SPELL_CHECKER_CATEGORY)
-                                .build(),
-
                         PropertyDefinition.builder(PluginParameter.SPELL_IGNOREUPPERCASE).name("Ignore uppercase")
-                                .type(PropertyType.BOOLEAN).description("Words that are all upper case are not spell checked, example: 'CIA'").defaultValue("true").subCategory(SPELL_CHECKER_CATEGORY).build(),
-
-                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREDIGITWORDS)
-                                .name("Ignore words with digits").type(PropertyType.BOOLEAN)
-                                .description("Words that have digits in them are not spell checked, example: 'match5'")
-                                .defaultValue("false").subCategory(SPELL_CHECKER_CATEGORY).build(),
-
-                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREINTERNETADDRESSES)
-                                .name("Ignore words like internet address").type(PropertyType.BOOLEAN)
-                                .description("Words that look like an Internet address are not spell checked, example: 'http://www.google.com'").defaultValue("true").subCategory(SPELL_CHECKER_CATEGORY)
-                                .build(),
+                                .type(PropertyType.BOOLEAN).description("Words that are all upper case are not spell checked, example: 'CIA'")
+                                .defaultValue("true").subCategory(SPELL_CHECKER_CATEGORY).build(),
+                                
                         PropertyDefinition.builder(PluginParameter.SPELL_THRESHOLD).name("Threshold value")
-                                .type(PropertyType.INTEGER).description("The maximum cost of suggested spelling. Any suggestions that cost more are thrown away").defaultValue("1")
-                                .subCategory(SPELL_CHECKER_CATEGORY).build(),
+                                .type(PropertyType.INTEGER).description("The maximum cost of suggested spelling. Any suggestions that cost more are thrown away")
+                                .defaultValue("1").subCategory(SPELL_CHECKER_CATEGORY).build(),
 
                         PropertyDefinition.builder(PluginParameter.EXCLUSION).name("Exclusions")
                                 .type(PropertyType.STRING).description("Defines resources to be excluded from analysis")
@@ -79,7 +67,9 @@ public class SpellCheckPlugin extends SonarPlugin {
                                 .defaultValue("/dict/english.0").subCategory(DICTIONARY_CATEGORY).build(),
 
                         PropertyDefinition.builder(PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY)
-                                .name("Alternative dictionary").type(PropertyType.STRING).description("The list of comma separated words to compile alternative  dictionary specific to your installation").type(PropertyType.TEXT).defaultValue("").subCategory(DICTIONARY_CATEGORY).build()
+                                .name("Alternative dictionary").type(PropertyType.STRING)
+                                .description("The list of comma separated words to compile alternative  dictionary specific to your installation")
+                                .type(PropertyType.TEXT).defaultValue("").subCategory(DICTIONARY_CATEGORY).build()
                 );
     }
 }

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/JavaSourceCodeWordFinder.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/JavaSourceCodeWordFinder.java
@@ -41,27 +41,32 @@ public class JavaSourceCodeWordFinder extends AbstractWordFinder implements
         currentWord.copy(nextWord);
 
         setSentenceIterator(currentWord);
-
-        int beginIndex = currentWord.getEnd();
-
-        WordFinderAutomaton automaton = new JavaCodeConventionEnglishAutomaton();
-        automaton.init();
-
-        automaton.searchNextWord(text, beginIndex);
-
-        if (!automaton.hasNextWord()) {
-            nextWord = null;
-        } else {
-            nextWord.setStart(automaton.getWordStart());
-            nextWord.setText(text.substring(automaton.getWordStart(),
-                    automaton.getWordEnd()));
-        }
-
-        if (isWordLessThenMinLength(currentWord)) {
-            currentWord.setText("");
-        }
+        
+        do {
+            nextWord = searchNextWord(nextWord, text);
+        } while (nextWord != null && isWordLessThenMinLength(nextWord));
 
         return currentWord;
+    }
+
+    private Word searchNextWord(Word nextWord, String text) {
+        Word newNextWord = new Word("", 0);
+        int beginIndex = nextWord.getEnd();
+        
+        WordFinderAutomaton automaton = new JavaCodeConventionEnglishAutomaton();
+        automaton.init();
+   
+        automaton.searchNextWord(text, beginIndex);
+   
+        if (!automaton.hasNextWord()) {
+            newNextWord = null;
+        } else {
+            newNextWord.setStart(automaton.getWordStart());
+            newNextWord.setText(text.substring(automaton.getWordStart(),
+                    automaton.getWordEnd()));
+        }
+        
+        return newNextWord;
     }
 
     private boolean isWordLessThenMinLength(final Word word) {

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/SpellCheckerFactory.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/SpellCheckerFactory.java
@@ -9,7 +9,6 @@ import org.sonar.api.config.Settings;
 
 public class SpellCheckerFactory implements BatchExtension {
 
-
     private Settings settings;
 
     public SpellChecker getSpellChecker() {
@@ -24,13 +23,17 @@ public class SpellCheckerFactory implements BatchExtension {
         spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREDIGITWORDS, settings.getBoolean(PluginParameter.SPELL_IGNOREDIGITWORDS));
         spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES, settings.getBoolean(PluginParameter.SPELL_IGNOREINTERNETADDRESSES));
         spellChecker.getConfiguration().setInteger(PluginParameter.SPELL_THRESHOLD, settings.getInt(PluginParameter.SPELL_THRESHOLD));
+        spellChecker.getConfiguration().setInteger(PluginParameter.SPELL_MINIMUMWORDLENGTH, settings.getInt(PluginParameter.SPELL_MINIMUMWORDLENGTH));
     }
-
 
     @Inject
     public void setSettings(Settings settings) {
         this.settings = settings;
+        
+        this.settings.setProperty(PluginParameter.SPELL_IGNOREMIXEDCASE, false);
+        this.settings.setProperty(PluginParameter.SPELL_IGNOREUPPERCASE, true);
+        this.settings.setProperty(PluginParameter.SPELL_IGNOREDIGITWORDS, false);
+        this.settings.setProperty(PluginParameter.SPELL_IGNOREINTERNETADDRESSES, false);
     }
-
 
 }

--- a/src/test/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/automaton/JavaCodeConventionEnglishAutomatonTest.java
+++ b/src/test/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/automaton/JavaCodeConventionEnglishAutomatonTest.java
@@ -117,6 +117,15 @@ public class JavaCodeConventionEnglishAutomatonTest {
 
         assertArrayEquals(expected, actual);
     }
+    
+    @Test
+    public void shouldFindFourWordsInAnnotationWithParam() throws Exception {
+        String text = "@SuppressWarnings(\"squid:S1161\")";
+        String[] expected = { "Suppress", "Warnings", "squid", "S" };
+        String[] actual = parseText(text);
+        
+        assertArrayEquals(expected, actual);
+    }
 
     @Test
     public void shouldFindFiveWordsInGeneric() throws Exception {


### PR DESCRIPTION
… true causes analysis to crash.

Fix searching of the next word in wordFinder.
Next word is searched accordingly to minWordLength: if nextWord length is less than minWordLength, then search another next word, and so on.
Remove unused spellcheck-plugin parameters from sonarqube user interface.