### PR TITLE
Fix issue #34: Remove misspelling metric because it is not populated

### DIFF
--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/SpellCheckPlugin.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/SpellCheckPlugin.java
@@ -7,8 +7,10 @@ import org.sonar.api.PropertyType;
 import org.sonar.api.SonarPlugin;
 import org.sonar.api.config.PropertyDefinition;
 
+import com.epam.sonarqube.spellcheck.plugin.decorator.SpellCheckMisspellingDecorator;
 import com.epam.sonarqube.spellcheck.plugin.issue.tracking.AddWordFromIssueFunction;
 import com.epam.sonarqube.spellcheck.plugin.issue.tracking.SpellCheckActionDefinition;
+import com.epam.sonarqube.spellcheck.plugin.metric.SpellCheckMetrics;
 import com.epam.sonarqube.spellcheck.plugin.profile.SpellCheckProfileDefinition;
 import com.epam.sonarqube.spellcheck.plugin.rule.SpellCheckRulesDefinition;
 import com.epam.sonarqube.spellcheck.plugin.sensor.SpellCheckIssuesSensor;
@@ -34,6 +36,8 @@ public class SpellCheckPlugin extends SonarPlugin {
                         SpellCheckMetrics.class,
                         // Sensors
                         SpellCheckIssuesSensor.class,
+                        //Decorators
+                        SpellCheckMisspellingDecorator.class,
                         //Issue review
                         AddWordFromIssueFunction.class,
                         //Instantiated by IoC as used injection

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/decorator/SpellCheckMisspellingDecorator.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/decorator/SpellCheckMisspellingDecorator.java
@@ -1,0 +1,45 @@
+package com.epam.sonarqube.spellcheck.plugin.decorator;
+
+import org.sonar.api.batch.Decorator;
+import org.sonar.api.batch.DecoratorContext;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.measures.MeasureUtils;
+import org.sonar.api.resources.Project;
+import org.sonar.api.resources.Resource;
+import org.sonar.api.resources.ResourceUtils;
+
+import com.epam.sonarqube.spellcheck.plugin.PluginParameter;
+import com.epam.sonarqube.spellcheck.plugin.metric.SpellCheckMetrics;
+
+public class SpellCheckMisspellingDecorator implements Decorator {
+
+    private final FileSystem fileSystem;
+    
+    public SpellCheckMisspellingDecorator(FileSystem fileSystem) {
+        this.fileSystem = fileSystem;
+    }
+
+    @Override
+    public boolean shouldExecuteOnProject(Project project) {
+        // This decorator is executed only when there are Java files
+        return fileSystem.hasFiles(fileSystem.predicates().hasLanguage(PluginParameter.PROFILE_LANGUAGE));
+    }
+
+    @Override
+    public void decorate(Resource resource, DecoratorContext context) {
+        // This method is executed on the whole tree of resources.
+        // Bottom-up navigation : Files -> Dirs -> modules -> project
+        if (!ResourceUtils.isFile(resource)) {
+            // we sum MISSPELLING metric values on resources different than file.
+            context.saveMeasure(
+                    SpellCheckMetrics.MISSPELLING,
+                    MeasureUtils.sum(true, context.getChildrenMeasures(SpellCheckMetrics.MISSPELLING)));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/metric/SpellCheckMetrics.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/metric/SpellCheckMetrics.java
@@ -1,4 +1,4 @@
-package com.epam.sonarqube.spellcheck.plugin;
+package com.epam.sonarqube.spellcheck.plugin.metric;
 
 
 import org.sonar.api.measures.CoreMetrics;
@@ -10,8 +10,8 @@ import java.util.List;
 
 public class SpellCheckMetrics implements Metrics {
 
-    public static final Metric MISSPELLING = new Metric.Builder("sonar.grammar.misspelling", "Misspelling", Metric.ValueType.STRING)
-            .setDescription("This is a metric to store a misspelled word in code")
+    public static final Metric<Integer> MISSPELLING = new Metric.Builder("sonar.spellcheck.misspelling", "Misspelling", Metric.ValueType.INT)
+            .setDescription("Count of misspelled words")
             .setDirection(Metric.DIRECTION_WORST)
             .setQualitative(false)
             .setDomain(CoreMetrics.DOMAIN_GENERAL)
@@ -19,6 +19,6 @@ public class SpellCheckMetrics implements Metrics {
 
     @Override
     public List<Metric> getMetrics() {
-        return Arrays.asList(MISSPELLING);
+        return Arrays.<Metric>asList(MISSPELLING);
     }
 }

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/sensor/SpellCheckIssuesSensor.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/sensor/SpellCheckIssuesSensor.java
@@ -106,11 +106,7 @@ public class SpellCheckIssuesSensor implements Sensor {
                     LOGGER.debug("Processing {}:\"{}\"", lineCounter, line);
                 }
                 int errors = processInputCodeCurrentLine(line, inputFile, lineCounter);
-                //filter errors, because it could be less than zero, 
-                //if spellchecker returns error code instead of errors count
-                if (errors > 0) {  
-                    errorsSum += errors;
-                }
+                errorsSum += errors;
                 lineCounter++;
             }
         } catch (IOException ex) {

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/SpellChecker.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/SpellChecker.java
@@ -39,12 +39,13 @@ public class SpellChecker implements BatchExtension {
         alternateDictionary = dictionaryLoader.loadAlternateDictionary();
     }
 
-    public void checkSpelling(final String inputLine, final SpellCheckListener spellCheckListener) {
+    public int checkSpelling(final String inputLine, final SpellCheckListener spellCheckListener) {
         parametersValidation(inputLine, spellCheckListener);
         com.swabunga.spell.event.SpellChecker spellCheck = createSpellChecker(spellCheckListener);
         JavaSourceCodeTokenizer sourceCodeTokenizer = new JavaSourceCodeTokenizer(inputLine, javaSourceCodeWordFinder);
-        spellCheck.checkSpelling(sourceCodeTokenizer);
+        int errors = spellCheck.checkSpelling(sourceCodeTokenizer);
         spellCheck.reset();
+        return errors;
     }
 
     private static void parametersValidation(final String inputLine, final SpellCheckListener spellCheckListener) {

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/SpellChecker.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/SpellChecker.java
@@ -39,11 +39,27 @@ public class SpellChecker implements BatchExtension {
         alternateDictionary = dictionaryLoader.loadAlternateDictionary();
     }
 
+    /**
+     * This method is called to check the spelling of the words in line.
+     * <p/>
+     * For each invalid word the action listeners will be informed with a new 
+     * SpellCheckEvent.<p>
+     *
+     * @param  inputLine  The line to be spell checked
+     * @param spellCheckListener Listener to be called when an invalid word during spell check process is found
+     * @return the number of errors found
+     */
     public int checkSpelling(final String inputLine, final SpellCheckListener spellCheckListener) {
         parametersValidation(inputLine, spellCheckListener);
         com.swabunga.spell.event.SpellChecker spellCheck = createSpellChecker(spellCheckListener);
         JavaSourceCodeTokenizer sourceCodeTokenizer = new JavaSourceCodeTokenizer(inputLine, javaSourceCodeWordFinder);
         int errors = spellCheck.checkSpelling(sourceCodeTokenizer);
+        
+        //filter errors, because it could be less than zero, 
+        //if spellchecker returns error code instead of errors count
+        if (errors < 0) {
+            errors = 0;
+        }
         spellCheck.reset();
         return errors;
     }

--- a/src/test/java/com/epam/sonarqube/spellcheck/plugin/decorator/SpellCheckMisspellingDecoratorTest.java
+++ b/src/test/java/com/epam/sonarqube/spellcheck/plugin/decorator/SpellCheckMisspellingDecoratorTest.java
@@ -1,0 +1,93 @@
+package com.epam.sonarqube.spellcheck.plugin.decorator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.sonar.api.batch.DecoratorContext;
+import org.sonar.api.batch.fs.FilePredicate;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.resources.Project;
+import org.sonar.api.resources.Resource;
+import org.sonar.api.resources.Scopes;
+
+import com.epam.sonarqube.spellcheck.plugin.decorator.SpellCheckMisspellingDecorator;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpellCheckMisspellingDecoratorTest {
+    private FileSystem fileSystem = createFileSystem();
+    
+    @InjectMocks
+    private SpellCheckMisspellingDecorator spellCheckMisspellingDecorator;
+
+    @Mock
+    private DecoratorContext context;
+    
+    @Mock
+    private Resource resource;
+    
+    @Mock
+    private Project project;
+    
+    @Test
+    public void shouldNotSaveMeasureWhenProcessFilesDuringDecorating() throws Exception {
+        when(resource.getScope()).thenReturn(Scopes.FILE);
+        
+        spellCheckMisspellingDecorator.decorate(resource, context);
+        verify(resource, atLeastOnce()).getScope();
+        verify(context, times(0)).saveMeasure(any(Metric.class), any(Double.class));
+    }
+    
+    @Test
+    public void shouldSaveMeasureWhenProcessDirectoryDuringDecorating() throws Exception {
+        when(resource.getScope()).thenReturn(Scopes.DIRECTORY);
+        
+        spellCheckMisspellingDecorator.decorate(resource, context);
+        verify(resource, atLeastOnce()).getScope();
+        verify(context, atLeastOnce()).saveMeasure(any(Metric.class), any(Double.class));
+    }
+    
+    @Test
+    public void shouldSaveMeasureWhenProcessProjectDuringDecorating() throws Exception {
+        when(resource.getScope()).thenReturn(Scopes.PROJECT);
+        
+        spellCheckMisspellingDecorator.decorate(resource, context);
+        verify(resource, atLeastOnce()).getScope();
+        verify(context, atLeastOnce()).saveMeasure(any(Metric.class), any(Double.class));
+    }
+    
+    @Test
+    public void shouldCallHasFilesWhileDecidingWhichFilesToDecorate() {
+        when(fileSystem.hasFiles(any(FilePredicate.class))).thenReturn(true);
+
+        spellCheckMisspellingDecorator.shouldExecuteOnProject(project);
+
+        verify(fileSystem, atLeastOnce()).hasFiles(any(FilePredicate.class));
+    }
+    
+    @Test
+    public void shouldReturnCorrectToStringOfSpellCheckIssuesSensorClass() throws Exception {
+        String expectedToStringValue = "SpellCheckMisspellingDecorator";
+
+        assertEquals(expectedToStringValue, spellCheckMisspellingDecorator.toString());
+    }
+    
+    private DefaultFileSystem createFileSystem() {
+        File sourceFile = new File("src/main/java/com/epam/sonarqube/spellcheck/plugin");
+        return spy(new DefaultFileSystem(sourceFile));
+    }
+    
+}

--- a/src/test/java/com/epam/sonarqube/spellcheck/plugin/metric/SpellCheckMetricsTest.java
+++ b/src/test/java/com/epam/sonarqube/spellcheck/plugin/metric/SpellCheckMetricsTest.java
@@ -1,8 +1,10 @@
-package com.epam.sonarqube.spellcheck.plugin;
+package com.epam.sonarqube.spellcheck.plugin.metric;
 
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
+
+import com.epam.sonarqube.spellcheck.plugin.metric.SpellCheckMetrics;
 
 public class SpellCheckMetricsTest {
 


### PR DESCRIPTION
Instead of removal - populate misspelling metric with measures.
Each measure is a count of misspelled words.