### PR TITLE
Skip and don't spellcheck dateFormat strings

### DIFF
--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/JavaSourceCodeSplitter.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/JavaSourceCodeSplitter.java
@@ -4,17 +4,28 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.epam.sonarqube.spellcheck.plugin.spellcheck.filter.WordFilter;
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.collect.ImmutableList;
 
 public class JavaSourceCodeSplitter {
 
+    private List<WordFilter> wordFilters = new LinkedList<>();
+
+    public void addWordFilter(WordFilter wordFilter) {
+        wordFilters.add(wordFilter);
+    }
+
     public List<String> split(String text) {
         List<String> list = new LinkedList<String>();
 
         String[] words = text.split("[^a-zA-Z]");
         for (String word : words) {
+            if (isWordFiltered(word)) { //skip words that are accepted by filter
+                continue;
+            }
+
             String[] wordsSplitByCamelCase = StringUtils
                     .splitByCharacterTypeCamelCase(word);
 
@@ -22,6 +33,15 @@ public class JavaSourceCodeSplitter {
         }
 
         return ImmutableList.<String> builder().addAll(list).build();
+    }
+
+    private boolean isWordFiltered(String word) {
+        for (WordFilter wordFilter : wordFilters) {
+            if (wordFilter.accept(word)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatDaysWordFilter.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatDaysWordFilter.java
@@ -1,0 +1,39 @@
+package com.epam.sonarqube.spellcheck.plugin.spellcheck.filter;
+
+import java.util.regex.Pattern;
+
+/**
+ * DateFormatDaysWordFilter class checks if given word is a correct dateFormat accordingly to {@link java.text.SimpleDateFormat},
+ * that represents DAYS.
+ * Checks only formats written without any separator-characters.
+ * It is assumed that in one dateFormat string, several groups of the same symbols are not allowed.
+ * For example, allowed ones: MMddyyyy, yyMMdd, yyyyMMMdd, etc.
+ * Not allowed ones: MMddyyyyMM, yyyyMMddyy, MMddMM, etc.
+ */
+public class DateFormatDaysWordFilter implements WordFilter {
+
+    private static final String DAYS_FORMAT_REGEX =
+            "(?:" +
+            //look for DAYS format pattern symbols in line; assume that further in processed line, already found symbols are not allowed
+            "(?:G{1,10})(?!.*G)" + //era designator
+            "|(?:y{1,10})(?!.*y)" + //year
+            "|(?:M{1,10})(?!.*M)" + //month in year
+            "|(?:d{1,10})(?!.*d)" + //day in month
+
+            "|(?:E{1,10})(?!.*E)" + //day in week
+            "|(?:D{1,10})(?!.*D)" + //day in year
+            "|(?:F{1,10})(?!.*F)" + //day of week in month
+            "|(?:w{1,10})(?!.*w)" + //week in year
+            "|(?:W{1,10})(?!.*W)" + //week in month
+
+            "|(?:z{1,10})(?!.*z)" + //time zone
+
+            ")+";
+
+    private Pattern dateFormatsPattern = Pattern.compile(DAYS_FORMAT_REGEX);
+
+    @Override
+    public boolean accept(String word) {
+        return dateFormatsPattern.matcher(word).matches();
+    }
+}

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatHoursWordFilter.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatHoursWordFilter.java
@@ -1,0 +1,37 @@
+package com.epam.sonarqube.spellcheck.plugin.spellcheck.filter;
+
+import java.util.regex.Pattern;
+
+/**
+ * DateFormatHoursWordFilter class checks if given word is a correct dateFormat accordingly to {@link java.text.SimpleDateFormat},
+ * that represents HOURS.
+ * Checks only formats written without any separator-characters.
+ * It is assumed that in one dateFormat string, several groups of the same symbols are not allowed.
+ * For example, allowed ones: HHmmss, HHmm, hmmssa, etc.
+ * Not allowed ones: HHmmssmm, HHmmaHH, aHHmma, etc.
+ */
+public class DateFormatHoursWordFilter implements WordFilter {
+
+    private static final String HOURS_FORMAT_REGEX =
+            "(?:" +
+            //look for HOURS format pattern symbols in line; assume that further in processed line, already found symbols are not allowed
+            "|(?:h{1,10})(?!.*h)" + //hour in am/pm (1-12)
+            "|(?:H{1,10})(?!.*H)" + //hour in day (0-23)
+            "|(?:m{1,10})(?!.*m)" + //minute in hour
+            "|(?:s{1,10})(?!.*s)" + //second in minute
+            "|(?:S{1,10})(?!.*S)" + //millisecond
+
+            "|(?:a{1,10})(?!.*a)" + //am/pm marker
+            "|(?:k{1,10})(?!.*k)" + //hour in day (1-24)
+            "|(?:K{1,10})(?!.*K)" + //hour in am/pm (0-11)
+            "|(?:z{1,10})(?!.*z)" + //time zone
+
+            ")+";
+
+    private Pattern dateFormatsPattern = Pattern.compile(HOURS_FORMAT_REGEX);
+
+    @Override
+    public boolean accept(String word) {
+        return dateFormatsPattern.matcher(word).matches();
+    }
+}

--- a/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/WordFilter.java
+++ b/src/main/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/WordFilter.java
@@ -1,0 +1,14 @@
+package com.epam.sonarqube.spellcheck.plugin.spellcheck.filter;
+
+/**
+ * Interface WordFilter provides filtering capabilities for separate words
+ */
+public interface WordFilter {
+    /**
+     * Method tests if {@code word} is accepted by this filter
+     *
+     * @param word word to be checked by filter
+     * @return true, if filter accepts this word; false - otherwise
+     */
+    boolean accept(String word);
+}

--- a/src/test/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatDaysWordFilterTest.java
+++ b/src/test/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatDaysWordFilterTest.java
@@ -1,0 +1,47 @@
+package com.epam.sonarqube.spellcheck.plugin.spellcheck.filter;
+
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+@RunWith(Theories.class)
+public class DateFormatDaysWordFilterTest {
+
+    private DateFormatDaysWordFilter dateFormatDaysWordFilter = new DateFormatDaysWordFilter();
+
+    @DataPoints
+    public static Object[][] correctDateFormats = {
+            {"yyyyMMdd", true},
+            {"MMyyydd", true},
+            {"dddMMMyy", true},
+            {"MMMdddyyyy", true},
+            {"ddMMyyyyG", true},
+            {"ddMMyyyyGGG", true},
+            {"EEDDFFwwWW", true},
+            {"yyyy", true},
+            {"MMM", true},
+            {"dd", true},
+    };
+
+    @DataPoints
+    public static Object[][] wrongOrNotAcceptedDateFormats = {
+            {"yyyyMMddyy", false},
+            {"yyyMonth", false},
+            {"MMddayyyM", false},
+            {"ABCyyyyMMdd", false},
+            {"Tesst", false},
+    };
+
+    @Theory
+    public void shouldCheckDateFormatsFromDataPoints(final Object...params) throws Exception {
+        String line = (String) params[0];
+        boolean expected = (Boolean)params[1];
+        boolean actual = dateFormatDaysWordFilter.accept(line);
+
+        assertThat(actual, is(expected));
+    }
+}

--- a/src/test/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatHoursWordFilterTest.java
+++ b/src/test/java/com/epam/sonarqube/spellcheck/plugin/spellcheck/filter/DateFormatHoursWordFilterTest.java
@@ -1,0 +1,58 @@
+package com.epam.sonarqube.spellcheck.plugin.spellcheck.filter;
+
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+@RunWith(Theories.class)
+public class DateFormatHoursWordFilterTest {
+
+    private DateFormatHoursWordFilter dateFormatHoursWordFilter = new DateFormatHoursWordFilter();
+
+    @DataPoints
+    public static Object[][] correctHourFormats = {
+            {"HHmmss", true},
+            {"Hms", true},
+            {"hhmmssa", true},
+            {"hhmmssaz", true},
+            {"kkkmmss", true},
+            {"KKmmss", true},
+            {"KKmmssz", true},
+            {"HH", true},
+            {"mm", true},
+            {"ss", true},
+    };
+
+    @DataPoints
+    public static Object[][] wrongOrNotAcceptedHourFormats = {
+            {"testHHmmss", false},
+            {"HHmmssHH", false},
+            {"HHmmamm", false},
+            {"aHHmma", false},
+            {"HHmmssTest", false},
+    };
+
+    @DataPoints
+    public static Object[][] ambiguousHourFormatsWhichAreAlsoRegularWords = {
+            {"sham", true},
+            {"mass", true},
+            {"mask", true},
+            {"ham", true},
+            {"hams", true},
+            {"mash", true},
+    };
+
+    @Theory
+    public void shouldCheckHourFormatsFromDataPoints(final Object...params) throws Exception {
+        String line = (String) params[0];
+        boolean expected = (Boolean)params[1];
+        boolean actual = dateFormatHoursWordFilter.accept(line);
+
+        assertThat(actual, is(expected));
+    }
+
+}


### PR DESCRIPTION
Checks only formats written without any separator-characters.
It is assumed that in one dateFormat string, several groups of the same
format symbols are not allowed. Otherwise - consider such words as regular
ones.
